### PR TITLE
Add white material handling for hull subsets

### DIFF
--- a/myproj/shader.py
+++ b/myproj/shader.py
@@ -24,68 +24,83 @@ class ShaderManager:
     # ----------------------------------------------------------------------
     
     @staticmethod
-    def make_dynamic_hull(
-            stage: Usd.Stage,
-            prim_path,                  # str | list[str]
-            idx,
-            *,
-            tex_name="live_hull",
-            tex_rgba=None,
-            size=(50, 300),              # (H, W)
-            mdl_path=MDL_PATH,
-            uv_set_index=0               # 0 = primvar:st
-        ):
-        # ---- normalise input --------------------------------------------------
-        if isinstance(prim_path, str):
-            prim_paths = [prim_path]
 
-        # ---- dynamic texture --------------------------------------------------
-        H, W = size
-        if tex_rgba is None:
-            tex_rgba = np.full((H, W, 4), [0, 255, 0, 255], np.uint8)
-            
-        tex_name = tex_name + str(idx)
-
-        provider = ui.DynamicTextureProvider(tex_name)
-        provider.set_data_array(tex_rgba, list(tex_rgba.shape))  # (H, W, 4)
-
-        # ---- material & shader ------------------------------------------------
-        mat_path = f"/World/Materials/{tex_name}"
-        shd_path = f"{mat_path}/OmniPBR"
-
-        mat = UsdShade.Material.Define(stage, mat_path)
-        shd = UsdShade.Shader.Define(stage, shd_path)
-        shd.CreateIdAttr("OmniPBR")
-
-        shd.CreateImplementationSourceAttr(UsdShade.Tokens.sourceAsset)
-        shd.SetSourceAsset(Sdf.AssetPath(mdl_path), "mdl")
-        shd.SetSourceAssetSubIdentifier("OmniPBR", "mdl")
-
-        shd.CreateInput("diffuse_texture_st_index",
-                        Sdf.ValueTypeNames.Int).Set(uv_set_index)
-        shd.CreateInput("diffuse_texture",
-                        Sdf.ValueTypeNames.Asset).Set(
-                            Sdf.AssetPath(f"dynamic://{tex_name}"))
-
-        surf = shd.CreateOutput("surface",      Sdf.ValueTypeNames.Token)
-        vol  = shd.CreateOutput("volume",       Sdf.ValueTypeNames.Token)
-        disp = shd.CreateOutput("displacement", Sdf.ValueTypeNames.Token)
-
-        mat.CreateSurfaceOutput().ConnectToSource(surf)
-        mat.CreateVolumeOutput().ConnectToSource(vol)
-        mat.CreateDisplacementOutput().ConnectToSource(disp)
-
-        # ---- bind to meshes ---------------------------------------------------
-
-        prim = stage.GetPrimAtPath(prim_path)
-        UsdShade.MaterialBindingAPI(prim).Bind(mat)
-
-        print(f"✅  Bound dynamic://{tex_name} (UV set {uv_set_index}) "
-            f"to {len(prim_paths)} prim(s)")
-
-        return provider        # keep this alive!
-
-
+        def make_dynamic_hull(
+                stage: Usd.Stage,
+                prim_path: str,
+                idx,
+                *,
+                tex_name="live_hull",
+                tex_rgba=None,
+                size=(50, 300),              # (H, W)
+                mdl_path=MDL_PATH,
+                uv_set_index=0               # 0 = primvar:st
+            ):
+            """Bind a dynamic material to hull faces and static white elsewhere."""
+    
+            # ---- dynamic texture -------------------------------------------------
+            H, W = size
+            if tex_rgba is None:
+                tex_rgba = np.full((H, W, 4), [0, 255, 0, 255], np.uint8)
+    
+            tex_name = tex_name + str(idx)
+    
+            provider = ui.DynamicTextureProvider(tex_name)
+            provider.set_data_array(tex_rgba, list(tex_rgba.shape))  # (H, W, 4)
+    
+            # ---- material & shader -----------------------------------------------
+            mat_path = f"/World/Materials/{tex_name}"
+            shd_path = f"{mat_path}/OmniPBR"
+    
+            mat = UsdShade.Material.Define(stage, mat_path)
+            shd = UsdShade.Shader.Define(stage, shd_path)
+            shd.CreateIdAttr("OmniPBR")
+    
+            shd.CreateImplementationSourceAttr(UsdShade.Tokens.sourceAsset)
+            shd.SetSourceAsset(Sdf.AssetPath(mdl_path), "mdl")
+            shd.SetSourceAssetSubIdentifier("OmniPBR", "mdl")
+    
+            shd.CreateInput("diffuse_texture_st_index",
+                            Sdf.ValueTypeNames.Int).Set(uv_set_index)
+            shd.CreateInput("diffuse_texture",
+                            Sdf.ValueTypeNames.Asset).Set(
+                                Sdf.AssetPath(f"dynamic://{tex_name}"))
+    
+            surf = shd.CreateOutput("surface",      Sdf.ValueTypeNames.Token)
+            vol  = shd.CreateOutput("volume",       Sdf.ValueTypeNames.Token)
+            disp = shd.CreateOutput("displacement", Sdf.ValueTypeNames.Token)
+    
+            mat.CreateSurfaceOutput().ConnectToSource(surf)
+            mat.CreateVolumeOutput().ConnectToSource(vol)
+            mat.CreateDisplacementOutput().ConnectToSource(disp)
+    
+            # ---- create static white material if needed --------------------------
+            white_mat_path = "/World/Materials/StaticWhite"
+            white_mat = UsdShade.Material.Get(stage, white_mat_path)
+            if not white_mat:
+                white_mat = UsdShade.Material.Define(stage, white_mat_path)
+                white_shd = UsdShade.Shader.Define(stage, f"{white_mat_path}/PreviewSurface")
+                white_shd.CreateIdAttr("UsdPreviewSurface")
+                white_shd.CreateInput("diffuseColor", Sdf.ValueTypeNames.Color3f).Set(Gf.Vec3f(1.0, 1.0, 1.0))
+                white_surf = white_shd.CreateOutput("surface", Sdf.ValueTypeNames.Token)
+                white_mat.CreateSurfaceOutput().ConnectToSource(white_surf)
+    
+            # ---- bind materials to subsets --------------------------------------
+            hullfaces_prim = stage.GetPrimAtPath(f"{prim_path}/Geom/Hullfaces")
+            transomfaces_prim = stage.GetPrimAtPath(f"{prim_path}/Geom/Transomfaces")
+            deckfaces_prim = stage.GetPrimAtPath(f"{prim_path}/Geom/Deckfaces")
+    
+            if hullfaces_prim:
+                UsdShade.MaterialBindingAPI(hullfaces_prim).Bind(mat)
+            if transomfaces_prim:
+                UsdShade.MaterialBindingAPI(transomfaces_prim).Bind(white_mat)
+            if deckfaces_prim:
+                UsdShade.MaterialBindingAPI(deckfaces_prim).Bind(white_mat)
+    
+            print(f"✅  Bound dynamic://{tex_name} to Hullfaces and static white to others")
+    
+            return provider        # keep this alive!
+    
     @staticmethod
     def create_dynamic_hull(
         stage: Usd.Stage,


### PR DESCRIPTION
## Summary
- update `make_dynamic_hull` so that dynamic material binds only to `Geom/Hullfaces`
- automatically create a static white material and bind it to `Geom/Transomfaces` and `Geom/Deckfaces`

## Testing
- `git commit -m "Update make_dynamic_hull to bind sub-prim materials"`

------
https://chatgpt.com/codex/tasks/task_e_6852feb61d1083238de41e0887129044